### PR TITLE
Fix typo pathlib

### DIFF
--- a/makepackage/makepackage.py
+++ b/makepackage/makepackage.py
@@ -59,7 +59,7 @@ def makepackage(package_name: str, CLI: bool) -> None:
         write_CLI_main(module_path, package_name)
 
 
-def make_dirs(root_path: pathlib.Path, package_name: str) -> None:
+def make_dirs(root_path: Path, package_name: str) -> None:
     """Create the directory structure."""
     check_if_not(
         root_path.exists(),


### PR DESCRIPTION
Fix the typo `pathlib.Path` to `Path` on line 62 of makepackage/makepackage.py.
Closes issue #5