### PR TITLE
Added build to project optional dependencies (pyproject.toml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ venv-*/
 
 # IDE config
 .vscode
+.idea

--- a/makepackage/write_pyproject.py
+++ b/makepackage/write_pyproject.py
@@ -34,7 +34,7 @@ def write_pyproject(path: Path, package_name: str, CLI: bool) -> None:
         }
 
     config["project.optional-dependencies"] = {
-        "dev": ["wheel", "black", "pytest", "mypy", "setuptools"]
+        "dev": ["wheel", "black", "pytest", "mypy", "setuptools", "build"]
     }
 
     with open(path / "pyproject.toml", "w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "makepackage"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
         { name = "Nyggus", email = "nyggus@gmail.com" },
         { name = "Patrick Boateng", email = "boatengpato.pb@gmail.com" },


### PR DESCRIPTION
build python package has been added to the ``project.optional-dependencies`` section of the ``pyproject.toml`` file of packages created using ``makepackage``.